### PR TITLE
Support for P514 (Gladius III) (#2614)

### DIFF
--- a/app/Peripherals/Mouse/Models/GladiusIIIWireless.cs
+++ b/app/Peripherals/Mouse/Models/GladiusIIIWireless.cs
@@ -1,13 +1,13 @@
 ﻿namespace GHelper.Peripherals.Mouse.Models
 {
     //P706_Wireless
-    public class GladiusIII : AsusMouse
+    public class GladiusIIIWireless : AsusMouse
     {
-        public GladiusIII() : base(0x0B05, 0x197F, "mi_00", true)
+        public GladiusIIIWireless() : base(0x0B05, 0x197F, "mi_00", true)
         {
         }
 
-        protected GladiusIII(ushort vendorId, bool wireless) : base(0x0B05, vendorId, "mi_00", wireless)
+        protected GladiusIIIWireless(ushort vendorId, bool wireless) : base(0x0B05, vendorId, "mi_00", wireless)
         {
         }
 
@@ -77,7 +77,7 @@
         }
     }
 
-    public class GladiusIIIWired : GladiusIII
+    public class GladiusIIIWired : GladiusIIIWireless
     {
         public GladiusIIIWired() : base(0x197d, false)
         {
@@ -86,6 +86,45 @@
         public override string GetDisplayName()
         {
             return "ROG Gladius III (Wired)";
+        }
+    }
+
+
+    //P514
+    public class GladiusIII : GladiusIIIWireless
+    {
+        public GladiusIII() : base(0x197B, false)
+        {
+        }
+
+        public override string GetDisplayName()
+        {
+            return "ROG Gladius III";
+        }
+
+        public override bool HasAutoPowerOff()
+        {
+            return false;
+        }
+
+        public override bool HasLowBatteryWarning()
+        {
+            return false;
+        }
+
+        public override bool HasBattery()
+        {
+            return false;
+        }
+
+        public override bool IsLightingModeSupported(LightingMode lightingMode)
+        {
+            return lightingMode == LightingMode.Static
+                || lightingMode == LightingMode.Breathing
+                || lightingMode == LightingMode.ColorCycle
+                || lightingMode == LightingMode.Rainbow
+                || lightingMode == LightingMode.React
+                || lightingMode == LightingMode.Comet;
         }
     }
 }

--- a/app/Peripherals/PeripheralsProvider.cs
+++ b/app/Peripherals/PeripheralsProvider.cs
@@ -198,8 +198,9 @@ namespace GHelper.Peripherals
             DetectMouse(new TUFM4WirelssCN());
             DetectMouse(new StrixImpactIIWireless());
             DetectMouse(new StrixImpactIIWirelessWired());
-            DetectMouse(new GladiusIII());
+            DetectMouse(new GladiusIIIWireless());
             DetectMouse(new GladiusIIIWired());
+            DetectMouse(new GladiusIII());
             DetectMouse(new GladiusIIIAimpointEva2());
             DetectMouse(new GladiusIIIAimpointEva2Wired());
             DetectMouse(new HarpeAceAimLabEdition());


### PR DESCRIPTION
* Support for Strix Carry (P508)

* Fixes polling rate, angle snapping and debounce for Gladius II Origin.

* The Gen2 version of the TuF M3 uses 0-100 for brightness.

* Adds support for ROG Strix Impact III (P518)

* Import/Export feature for mice.

* Suppor for Strix Impact (P303)

* Support for Strix Impact II Electro Punk

* Strix Carry has 50 DPI minimum and increments of 50.

* Respect top-most setting of GHelper

* Fixes to the buttons to be wider to fit longer translations.

* Basic support for the Galdius III EVA02

* Gladius wireless and wired PIDs were switched

* Add support for the chinese variant of the M4 Wireless, the P310

* Apparently there is another Gladius III that is not wireless at all. Renaming the wireless to make it a little less confusing.

* Adds Support for Galdius III (wired) P514